### PR TITLE
Fix keysort/2 predicate to not discard elements with the same key

### DIFF
--- a/src/system/bootstrap_js.pl
+++ b/src/system/bootstrap_js.pl
@@ -551,12 +551,8 @@ partition([X|Xs],Y,Ls,[X|Rs]) :-
         partition(Xs,Y,Ls,Rs).
 partition([],_,[],[]).
 
-key_partition([XKey-_|Xs],YKey,Ls,Rs) :-
-        XKey == YKey,
-        !,
-        key_partition(Xs,YKey,Ls,Rs).
 key_partition([XKey-X|Xs],YKey,[XKey-X|Ls],Rs) :-
-        XKey @< YKey,
+        XKey @=< YKey,
         !,
         key_partition(Xs,YKey,Ls,Rs).
 key_partition([XKey-X|Xs],YKey,Ls,[XKey-X|Rs]) :-


### PR DESCRIPTION
Without this fix, we get e.g.

```text
| ?- keysort([2-99, 1-a, 3-f(X), 1-z, 1-a, 2-44], Sorted).

Sorted = [1-a,2-99,3-f(X)]
yes
```

The fix gives the expected result:

```
| ?- keysort([2-99, 1-a, 3-f(X), 1-z, 1-a, 2-44], Sorted).

Sorted = [1-a,1-z,1-a,2-44,2-99,3-f(X)]
yes
```